### PR TITLE
feat: semantic versioning changelog

### DIFF
--- a/.changelog/changelog-template.hbs
+++ b/.changelog/changelog-template.hbs
@@ -1,0 +1,34 @@
+# Changelog
+
+This document outlines the summary of all notable changes to the project.
+
+{{#each releases}}
+  {{#if href}}
+    ## [{{title}}]({{href}}) - {{niceDate}}
+  {{else}}
+    ## {{title}} - {{niceDate}}
+  {{/if}}
+
+  {{#commit-list commits heading='### Breaking Changes ⚠️' message='BREAKING CHANGE'}}
+  {{subject}} ([`{{shorthash}}`]({{href}}))
+  {{/commit-list}}
+
+  {{#commit-list commits heading='### New ✨' message='feat(\([\w-]*?\))?:'}}
+  - {{subject}} ([`{{shorthash}}`]({{href}}))
+  {{/commit-list}}
+
+  {{#commit-list commits heading='### Bug fixes 🐛' message='fix(\([\w-]*?\))?:'}}
+  - {{subject}} ([`{{shorthash}}`]({{href}}))
+  {{/commit-list}}
+
+  {{#commit-list commits heading='### Documentation 📚' message='docs(\([\w-]*?\))?:'}}
+  - {{subject}} ([`{{shorthash}}`]({{href}}))
+  {{/commit-list}}
+
+  {{#commit-list commits heading='### Improvements 📈' message='(build|chore|ci|perf|refactor|revert|style|test)(\([\w-]*?\))?:'}}
+  - {{#emoji subject }}{{/emoji}}{{#if href}} ([`{{shorthash}}`]({{href}})){{/if}}
+{{/commit-list}}
+
+----
+
+{{/each}}

--- a/.changelog/helper.js
+++ b/.changelog/helper.js
@@ -1,0 +1,17 @@
+module.exports = (Handlebars) => {
+  Handlebars.registerHelper('emoji', (message, options) => {
+    const emojies = {
+      build: '⚙️',
+      chore: 'ℹ️',
+      ci: '🚀',
+      perf: '🚄',
+      refactor: '♻️',
+      revert: '⏮️',
+      style: '🎨',
+      test: '✅'
+    }
+    
+    let match = message.match(/(\w*)(\([\w-]*?\))?:/);
+    return match ? emojies[match[1]] + ' ' + message : message
+  });
+}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+git-tag-version=false
+sign-git-commit=true
+sign-git-tag=true

--- a/bump-version.js
+++ b/bump-version.js
@@ -1,0 +1,34 @@
+const { execSync } = require('child_process');
+
+// Check the type of the latest commit to know what version should be bumped
+const latestCommitMessage = execSync('git log -1 --format=%s').toString('utf-8');
+const commitParts = latestCommitMessage.matchAll(/(?<type>build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(?<scope>\(\w*?\))?(?<breaking>!)?:/g);
+
+let newBumbedVersion = '';
+
+for (const commitPart of commitParts) {
+  if (commitPart.groups.breaking) {
+    newBumbedVersion = execSync('npm version major').toString('utf-8');
+  } else if (commitPart.groups.type === 'feat') {
+    newBumbedVersion = execSync('npm version minor').toString('utf-8');
+  } else if (commitPart.groups.type === 'fix') {
+    newBumbedVersion = execSync('npm version patch').toString('utf-8');
+  } else {
+    newBumbedVersion = execSync('npm version minor').toString('utf-8');
+  }
+
+  newBumbedVersion = newBumbedVersion.trim();
+
+  // Create a new tag and assign it to the latest commit
+  execSync(`git tag ${newBumbedVersion}`);
+
+  // Generate changelog for the latest release
+  execSync('npm run changelog');
+
+  // Commit bumped package.jspon and generated CHANGELOG as a chore(release)
+  execSync(`git add package.json package-lock.json CHANGELOG.md && git commit -q -m "chore(release): ${newBumbedVersion}"`);
+
+  // Push commit along with the tag to the main branch
+  execSync('git push --follow-tags origin main');
+  // execSync('git push origin --tags');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "auto-changelog": "^2.4.0",
         "axios": "^0.25.0",
         "chai": "^4.3.6",
         "chai-as-promised": "^7.1.1",
@@ -969,6 +970,40 @@
       "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
       "dev": true
     },
+    "node_modules/auto-changelog": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.4.0.tgz",
+      "integrity": "sha512-vh17hko1c0ItsEcw6m7qPRf3m45u+XK5QyCrrBFViElZ8jnKrPC1roSznrd1fIB/0vR/zawdECCRJtTuqIXaJw==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^7.2.0",
+        "handlebars": "^4.7.7",
+        "node-fetch": "^2.6.1",
+        "parse-github-url": "^1.0.2",
+        "semver": "^7.3.5"
+      },
+      "bin": {
+        "auto-changelog": "src/index.js"
+      },
+      "engines": {
+        "node": ">=8.3"
+      }
+    },
+    "node_modules/auto-changelog/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/axios": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
@@ -1261,6 +1296,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",
@@ -2627,6 +2671,36 @@
         "node": ">=4.x"
       }
     },
+    "node_modules/handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/handlebars/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3712,6 +3786,32 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -4105,6 +4205,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-github-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
+      "dev": true,
+      "bin": {
+        "parse-github-url": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/parse-json": {
@@ -5253,6 +5365,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -5338,6 +5456,19 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -5414,6 +5545,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5459,6 +5606,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "node_modules/workerpool": {
       "version": "6.2.0",
@@ -6332,6 +6485,30 @@
       "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
       "dev": true
     },
+    "auto-changelog": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/auto-changelog/-/auto-changelog-2.4.0.tgz",
+      "integrity": "sha512-vh17hko1c0ItsEcw6m7qPRf3m45u+XK5QyCrrBFViElZ8jnKrPC1roSznrd1fIB/0vR/zawdECCRJtTuqIXaJw==",
+      "dev": true,
+      "requires": {
+        "commander": "^7.2.0",
+        "handlebars": "^4.7.7",
+        "node-fetch": "^2.6.1",
+        "parse-github-url": "^1.0.2",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "axios": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
@@ -6541,6 +6718,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true
     },
     "commondir": {
@@ -7554,6 +7737,27 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.0",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
+        "wordwrap": "^1.0.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -8341,6 +8545,21 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true
     },
+    "neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -8641,6 +8860,12 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "parse-github-url": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-github-url/-/parse-github-url-1.0.2.tgz",
+      "integrity": "sha512-kgBf6avCbO3Cn6+RnzRGLkUsv4ZVqv/VfAYkRsyBcgkshNvVBkRn1FEZcW0Jb+npXQWm2vHPnnOqFteZxRRGNw==",
+      "dev": true
     },
     "parse-json": {
       "version": "4.0.0",
@@ -9491,6 +9716,12 @@
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
+    },
     "tsconfig-paths": {
       "version": "3.14.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
@@ -9560,6 +9791,13 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "uglify-js": {
+      "version": "3.15.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
+      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
+      "dev": true,
+      "optional": true
+    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -9617,6 +9855,22 @@
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -9649,6 +9903,12 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "workerpool": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "antmarky",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Antmarky is a static-site generator for Markdown based on Node.js/EJS",
   "main": "server.js",
   "scripts": {
     "build": "node src/commands/build.js",
     "serve": "node server.js",
     "lint": "semistandard",
-    "test": "nyc --reporter=lcovonly --reporter=text mocha 'test/**/*.test.js'"
+    "test": "nyc --reporter=lcovonly --reporter=text mocha 'test/**/*.test.js'",
+    "bump": "node bump-version.js",
+    "changelog": "auto-changelog --handlebars-setup .changelog/helper.js --template .changelog/changelog-template.hbs --commit-limit false"
   },
   "semistandard": {
     "ignore": [
@@ -18,6 +20,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "auto-changelog": "^2.4.0",
     "axios": "^0.25.0",
     "chai": "^4.3.6",
     "chai-as-promised": "^7.1.1",


### PR DESCRIPTION
This update includes:
- full switch to comventional commits
- auto-generated conventional CHANGELOG.md
- custom changelog template
- helper function for changelog to transform data
- npm package configuration to ensure proper generation process
- custom script to:
  - autmatically bump package.json version
  - tag the latest commit with the bumped version
  - generate changelog
  - commit changes as chore(release)
  - push commit to the main branch along with the tag